### PR TITLE
Fix ffmpeg and clean

### DIFF
--- a/src/utils_glx.h
+++ b/src/utils_glx.h
@@ -55,13 +55,6 @@ typedef void (*PFNGLXRELEASETEXIMAGEEXTPROC)(Display *, GLXDrawable, int);
 typedef void (*PFNGLMULTITEXCOORD2FPROC) (GLenum target, GLfloat s, GLfloat t);
 #endif
 
-#if GL_GLEXT_VERSION >= 85
-/* XXX: PFNGLMULTITEXCOORD2FPROC got out of the GL_VERSION_1_3_DEPRECATED
-   block and is not defined if GL_VERSION_1_3 is defined in <GL/gl.h>
-   Redefine the type here as an interim solution */
-typedef void (*PFNGLMULTITEXCOORD2FPROC) (GLenum target, GLfloat s, GLfloat t);
-#endif
-
 #ifndef GL_FRAMEBUFFER_BINDING
 #define GL_FRAMEBUFFER_BINDING GL_FRAMEBUFFER_BINDING_EXT
 #endif

--- a/src/vdpau_driver.c
+++ b/src/vdpau_driver.c
@@ -184,13 +184,13 @@ vdpau_common_Terminate(vdpau_driver_data_t *driver_data)
 static VAStatus
 vdpau_common_Initialize(vdpau_driver_data_t *driver_data)
 {
-    if (!driver_data->x11_dpy) {
+    const char *x11_dpy_name = NULL;
+    if (driver_data->x11_dpy) {
         /* vaGetDisplayDRM() doesn't fill ->x11_dpy */
-        return VA_STATUS_ERROR_UNKNOWN;
+        x11_dpy_name = XDisplayString(driver_data->x11_dpy);
     }
 
     /* Create a dedicated X11 display for VDPAU purposes */
-    const char * const x11_dpy_name = XDisplayString(driver_data->x11_dpy);
     driver_data->vdp_dpy = XOpenDisplay(x11_dpy_name);
     /* Fallback to existing X11 display */
     driver_data->x_fallback = false;
@@ -198,6 +198,10 @@ vdpau_common_Initialize(vdpau_driver_data_t *driver_data)
         driver_data->x_fallback = true;
         driver_data->vdp_dpy = driver_data->x11_dpy;
         printf("Failed to create dedicated X11 display!\n");
+    }
+
+    if (!driver_data->vdp_dpy) {
+        return VA_STATUS_ERROR_UNKNOWN;
     }
         
     VdpStatus vdp_status;

--- a/src/vdpau_video.c
+++ b/src/vdpau_video.c
@@ -318,6 +318,8 @@ vdpau_QuerySurfaceAttributes(
     unsigned int       *num_attribs
 )
 {
+    unsigned int num_formats, i;
+    VAImageFormat format_list[32];
     VDPAU_DRIVER_DATA_INIT;
 
     object_config_p obj_config;
@@ -327,8 +329,10 @@ vdpau_QuerySurfaceAttributes(
     if (!attrib_list && !num_attribs)
         return VA_STATUS_ERROR_INVALID_PARAMETER;
 
+    vdpau_QueryImageFormats(ctx, format_list, &num_formats);
+
     if (!attrib_list) {
-        *num_attribs = 2;
+        *num_attribs = 2 + num_formats;
         return VA_STATUS_SUCCESS;
     }
 
@@ -352,6 +356,13 @@ vdpau_QuerySurfaceAttributes(
         attrib_list[1].flags = VA_SURFACE_ATTRIB_GETTABLE;
         attrib_list[1].value.type = VAGenericValueTypeInteger;
         attrib_list[1].value.value.i = max_height;
+
+        for (i = 0; i < num_formats && i+2 < *num_attribs; i++) {
+            attrib_list[i+2].type = VASurfaceAttribPixelFormat;
+            attrib_list[i+2].flags = VA_SURFACE_ATTRIB_GETTABLE;
+            attrib_list[i+2].value.type = VAGenericValueTypeInteger;
+            attrib_list[i+2].value.value.i = format_list[i].fourcc;
+        }
     }
 
     return VA_STATUS_SUCCESS;

--- a/src/vdpau_video.h
+++ b/src/vdpau_video.h
@@ -291,13 +291,12 @@ vdpau_CreateSurfaceFromCIFrame(
 ) attribute_hidden;
 
 // vaCreateSurfaceFromV4L2Buf
-// XXX: compile problem?
-/*VAStatus
+VAStatus
 vdpau_CreateSurfaceFromV4L2Buf(
     VADriverContextP    ctx,
     int                 v4l2_fd,
     VASurfaceID        *surface
-) attribute_hidden;*/
+) attribute_hidden;
 
 // vaCopySurfaceToBuffer
 VAStatus


### PR DESCRIPTION
Idk why @thesword53 never brought back their work here
Anyhow mpv finally works again now (I also took advantage of my [failed arch PR](https://gitlab.archlinux.org/archlinux/packaging/packages/libva-vdpau-driver/-/merge_requests/1) to do some sanity check against the original package..)

I mean, `--hwdec=vaapi-copy` that is, for some reason the normal vaapi still fails with error "Failed to create surface: 14" (and it doesn't seem like a regression? if not any I tried it all the way back to ffmpeg 4.0 and mpv 0.35)